### PR TITLE
Adding the jest-pact dependecy and updating the libs to make it work with node version 14

### DIFF
--- a/pact/package.json
+++ b/pact/package.json
@@ -19,9 +19,10 @@
     "joi": "^17.3.0"
   },
   "devDependencies": {
-    "@pact-foundation/pact": "^9.14.0",
-    "axios": "^0.21.1",
-    "jest": "^26.6.3",
+    "@pact-foundation/pact": "^9.18.1",
+    "axios": "^0.27.2",
+    "jest": "^28.1.3",
+    "jest-pact": "^0.9.4",
     "cross-env": "^7.0.3"
   }
 }


### PR DESCRIPTION
This pull request is to update the Pact dependencies of the project to make it work with and make it work with a more recent version of Node.

Tested against
node - v14.17.1
npm - 6.14.13


consumer/consumer-contract-a.spec.js
  Country Service
    When a request to list all countries is made
      ✓ should return the correct population (14 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        4.413 s
Ran all test suites matching /consumer\/consumer-contract-a.spec.js/i.
